### PR TITLE
Update CI to test new Python versions and prepare 1.0.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,26 @@
 language: python
 
-python:
-- "2.6"
-- "2.7"
-- "3.4"
-- "3.5"
-- "3.6"
+dist: bionic
+
+matrix:
+  include:
+  - python: 2.7
+  - python: 3.4
+    dist: trusty
+  - python: 3.5
+    dist: trusty
+  - python: 3.6
+  - python: 3.7
+  - python: 3.8
 
 install:
-- pip install -U pip setuptools
-- pip install .
+- pip install --upgrade pip setuptools
 - pip install -r requirements-test.txt
-- pip install python-coveralls
+- pip install .
+- pip install coveralls
 
 script:
-- py.test -v --instafail --pep8 --cov pypsexec --cov-report term-missing
+- py.test -v --pep8 --cov pypsexec --cov-report term-missing
 
 after_success:
 - coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.0 - TBD
+
+* Dropped support for Python 2.6
+* Set minumum version of smbprotocol to `1.0.0` to take advantage of new simpler library.
+
+
 ## 0.1.0 2018-03-07
 
 Initial release of pypsexec.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
-# Windows Server 2016
-image: Visual Studio 2017
+# Windows Server 2019
+image: Visual Studio 2019
 
 environment:
   global:
@@ -18,6 +18,8 @@ environment:
   - PYTHON: Python35-x64
   - PYTHON: Python36
   - PYTHON: Python36-x64
+  - PYTHON: Python37
+  - PYTHON: Python37-x64
 
 init:
 - ps: |
@@ -29,12 +31,12 @@ init:
     $env:PYPSEXEC_PASSWORD = [Microsoft.Win32.Registry]::GetValue("HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon", "DefaultPassword", '')
 
 install:
-- ps: |
-    pip install -U pip setuptools
-    pip install .
-    pip install -r requirements-test.txt
+- cmd: python -m pip install --upgrade pip
+- cmd: pip install --upgrade setuptools
+- cmd: pip install -r requirements-test.txt
+- cmd: pip install .
 
 build: off  # Do not run MSBuild, build stuff at install step
 
 test_script:
-- ps: py.test -v --instafail --pep8 --cov pypsexec --cov-report term-missing
+- ps: py.test -v --pep8 --cov pypsexec --cov-report term-missing

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
-pytest<=4.0.0
+pytest>=4.0.0
 pytest-cov
 pytest-pep8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
-pytest<=3.2.5
+pytest<=4.0.0
 pytest-cov
 pytest-pep8
-pytest-instafail

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,10 @@
 universal = 1
 
 [tool:pytest]
+pep8maxlinelength = 119
 pep8ignore = setup.py E501
+markers =
+    pep8: Satisfy pytest warning about custom markers
 
 [metadata]
 license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
-# coding: utf-8
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2019, Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
 from setuptools import setup
 
@@ -14,12 +16,13 @@ except ImportError:
 
 setup(
     name='pypsexec',
-    version='0.1.0',
+    version='1.0.0',
     packages=['pypsexec'],
     install_requires=[
         'smbprotocol',
-        'six'
+        'six',
     ],
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     author='Jordan Borean',
     author_email='jborean93@gmail.com',
     url='https://github.com/jborean93/pypsexec',
@@ -31,11 +34,12 @@ setup(
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,11 @@
 [tox]
-envlist = py26,py27,py34,py35,py36
+envlist = py27,py34,py35,py36,py37,py38
+skip_missing_interpreters = true
 
 [testenv]
-deps= -rrequirements-test.txt
-commands=py.test -v --pep8 --cov pypsexec --cov-report term-missing
-passenv=PYPSEXEC_*
+deps =
+    -r{toxinidir}/requirements-test.txt
+commands =
+    py.test -v --pep8 --cov pypsexec --cov-report term-missing
+passenv =
+    PYPSEXEC_*


### PR DESCRIPTION
Prepare CI with newer Python versions and setup repo for the 1.0.0 release. This also officially drops Python 2.6 support due to its advanced age.