### PR TITLE
Set default process bitness to 64-bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## 1.0.0 - TBD
 
-* Dropped support for Python 2.6 and Python 3.4
-* Updated the `PAExec` executable to `1.27`
+* Breaking change where processes are run as the native architecture bitness, e.g. 64-bit on 64-bit OS' and 32-bit on 32-bit OS'
+    * This changes the old behaviour of always running as a 32-bit process.
+    * Any application relying on running with 32-bit paths will need to set `wow64=True` on `run_executable()` to restore the older behaviour.
+* Dropped support for Python 2.6 and Python 3.4.
+* Updated the `PAExec` executable to `1.27`.
 * Set minumum version of smbprotocol to `1.0.0` to take advantage of new simpler library.
 
 

--- a/pypsexec/client.py
+++ b/pypsexec/client.py
@@ -238,7 +238,7 @@ class Client(object):
                        priority=ProcessPriority.NORMAL_PRIORITY_CLASS,
                        remote_log_path=None, timeout_seconds=0,
                        stdout=OutputPipeBytes, stderr=OutputPipeBytes,
-                       stdin=None):
+                       stdin=None, wow64=False):
         """
         Runs a command over the PAExec/PSExec interface based on the options
         provided. At a minimum the executable argument is required and the
@@ -298,6 +298,7 @@ class Client(object):
             stderr
         :param stdin: Either a byte string of generator that yields multiple
             byte strings to send over the stdin pipe.
+        :param wow64: Set to True to run the executable as a 32-bit process.
         :return: Tuple(stdout, stderr, rc)
             stdout: (Bytes) The stdout.get_bytes() return result
             stderr: (Bytes) The stderr.get_bytes() return result
@@ -337,6 +338,7 @@ class Client(object):
         settings['arguments'] = self._encode_string(arguments)
         settings['remote_log_path'] = self._encode_string(remote_log_path)
         settings['timeout_seconds'] = timeout_seconds
+        settings['disable_file_redirection'] = not wow64
 
         input_data = PAExecSettingsMsg()
         input_data['unique_id'] = self._unique_id

--- a/pypsexec/scmr.py
+++ b/pypsexec/scmr.py
@@ -647,11 +647,8 @@ class SCMRApi(object):
         return_code = struct.unpack("<i", res)[0]
         self._parse_error(return_code, "RStartServiceW")
 
-    def create_service_w(self, server_handle, service_name,
-                               display_name, desired_access, service_type,
-                               start_type, error_control, path,
-                               load_order_group, tag_id, dependencies,
-                               username, password):
+    def create_service_w(self, server_handle, service_name, display_name, desired_access, service_type, start_type,
+                         error_control, path, load_order_group, tag_id, dependencies, username, password):
         # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-scmr/6a8ca926-9477-4dd4-b766-692fab07227e
         opnum = 12
 

--- a/pypsexec/scmr.py
+++ b/pypsexec/scmr.py
@@ -342,7 +342,7 @@ class Service(object):
         if self._handle:
             return
 
-        self._handle = self._scmr.create_service_wow64_w(
+        self._handle = self._scmr.create_service_w(
             self._scmr_handle,
             self.name,
             self.name,
@@ -647,13 +647,13 @@ class SCMRApi(object):
         return_code = struct.unpack("<i", res)[0]
         self._parse_error(return_code, "RStartServiceW")
 
-    def create_service_wow64_w(self, server_handle, service_name,
+    def create_service_w(self, server_handle, service_name,
                                display_name, desired_access, service_type,
                                start_type, error_control, path,
                                load_order_group, tag_id, dependencies,
                                username, password):
-        # https://msdn.microsoft.com/en-us/library/cc245925.aspx
-        opnum = 45
+        # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-scmr/6a8ca926-9477-4dd4-b766-692fab07227e
+        opnum = 12
 
         data = server_handle
         data += self._marshal_string(service_name)
@@ -679,11 +679,11 @@ class SCMRApi(object):
         pass_len = len(pass_bytes) if password else 0
         data += struct.pack("<i", pass_len)
 
-        res = self._invoke("RCreateServiceWOW64W", opnum, data)
+        res = self._invoke("RCreateServiceW", opnum, data)
         tag_id = res[0:4]
         service_handle = res[4:24]
         return_code = struct.unpack("<i", res[24:])[0]
-        self._parse_error(return_code, "RCreateServiceWOW64W")
+        self._parse_error(return_code, "RCreateServiceW")
         return tag_id, service_handle
 
     def _invoke(self, function_name, opnum, data):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -377,6 +377,18 @@ class TestClientFunctional(object):
         assert actual[2] != 0
         time.sleep(1)
 
+    @pytest.mark.parametrize('wow, expected', [(None, 8), (False, 8), (True, 4)])
+    def test_process_architecture(self, wow, expected, client):
+        kwargs = {
+            'arguments': '[System.IntPtr]::Size',
+        }
+        if wow is not None:
+            kwargs['wow64'] = wow
+
+        actual = client.run_executable('powershell.exe', **kwargs)
+
+        assert int(actual[0].rstrip(b'\r\n')) == expected
+
     def test_cleanup_with_older_processes(self, client):
         # create a new service with different pid and service name
         username = os.environ['PYPSEXEC_USERNAME']


### PR DESCRIPTION
Because 1.0.0 is a major change I'm happy to add the ability to specify the bitness of a process to whatever is the native size of the target. The `wow64` kwarg in `run_executable` can still bring back the older behaviour if people still want that behaviour.

Unfortunately this will be a backwards incompatible change if they are relying on using the 32-bit paths like `C:\Windows\sysnative` but I believe sane defaults dictate that we use the native size instead and allow a toggle to change that.

Fixes https://github.com/jborean93/pypsexec/issues/18