### PR TITLE
Handle non-ASCII service names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     * Any application relying on running with 32-bit paths will need to set `wow64=True` on `run_executable()` to restore the older behaviour.
 * Dropped support for Python 2.6 and Python 3.4.
 * Updated the `PAExec` executable to `1.27`.
+* Handle non-ASCII characters when enumerating the services on the remote host.
 
 
 ## 0.1.0 2018-03-07

--- a/pypsexec/scmr.py
+++ b/pypsexec/scmr.py
@@ -586,10 +586,10 @@ class SCMRApi(object):
         self._parse_error(return_code, "REnumServicesStatusW")
 
         def extract_unicode(buffer):
-            null_idx = buffer.index(b"\x00\x00")
             # https://github.com/jborean93/pypsexec/issues/36
             # When ending with ASCII chars the 2nd byte is 00.
-            null_idx = null_idx + 1 if null_idx % 2 else null_idx
+            null_idx = buffer.index(b"\x00\x00")
+            null_idx += null_idx % 2
             return buffer[:null_idx].decode('utf-16-le')
 
         # now we have all the data, let's unpack it

--- a/pypsexec/scmr.py
+++ b/pypsexec/scmr.py
@@ -589,7 +589,7 @@ class SCMRApi(object):
             null_idx = buffer.index(b"\x00\x00")
             # https://github.com/jborean93/pypsexec/issues/36
             # When ending with ASCII chars the 2nd byte is 00.
-            null_idx = null_idx + 1 if null_idx % 1 else null_idx
+            null_idx = null_idx + 1 if null_idx % 2 else null_idx
             return buffer[:null_idx].decode('utf-16-le')
 
         # now we have all the data, let's unpack it


### PR DESCRIPTION
The current logic expects the service name to end in an ASCII char so the last byte becomes `xx 00`. This makes the logic more flexible and handles the cases when that does not occur.

Fixes https://github.com/jborean93/pypsexec/issues/36