### PR TITLE
Add PyInstaller hooks

### DIFF
--- a/pypsexec/__pyinstaller/__init__.py
+++ b/pypsexec/__pyinstaller/__init__.py
@@ -1,0 +1,5 @@
+import os
+
+
+def get_hook_dirs():
+    return [os.path.dirname(__file__)]

--- a/pypsexec/__pyinstaller/hook-pypsexec.py
+++ b/pypsexec/__pyinstaller/hook-pypsexec.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_all
+
+datas, binaries, hiddenimports = collect_all('pypsexec')

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,7 @@ max-line-length = 119
 
 [tool:pytest]
 junit_family=xunit2
+
+[options.entry_points]
+pyinstaller40 =
+  hook-dirs = pypsexec.__pyinstaller:get_hook_dirs

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(abs_path('README.md'), mode='rb') as fd:
 setup(
     name='pypsexec',
     version='0.2.0',
-    packages=['pypsexec'],
+    packages=['pypsexec', 'pypsexec.__pyinstaller'],
     install_requires=[
         'smbprotocol',
         'six',


### PR DESCRIPTION
These hooks allow pypsexec to be properly packaged with PyInstaller. Specifically, they help Pyinstaller locate the paexec.exe binary.

You can read more about PyInstaller [here](https://pyinstaller.readthedocs.io/en/stable/index.html), and more about PyInstaller hooks [here](https://pyinstaller.readthedocs.io/en/stable/hooks.html).

Fixes #43