### PR TITLE
adapt to timezone-aware objects

### DIFF
--- a/tests/test_paexec.py
+++ b/tests/test_paexec.py
@@ -7,6 +7,7 @@ import pytest
 
 from datetime import (
     datetime,
+    timezone,
 )
 
 from pypsexec.exceptions import (
@@ -265,7 +266,7 @@ class TestPAExecSettingsMsg(object):
         assert src_files[0]['filename'].get_value() == \
             "src1".encode('utf-16-le')
         assert src_files[0]['file_last_write'].get_value() == \
-            datetime.utcfromtimestamp(0)
+            datetime.utcfromtimestamp(0).replace(tzinfo=timezone.utc)
         assert src_files[0]['file_version_ls'].get_value() == 0
         assert src_files[0]['file_version_ms'].get_value() == 0
         assert not src_files[0]['copy_file'].get_value()
@@ -273,7 +274,7 @@ class TestPAExecSettingsMsg(object):
         assert src_files[1]['filename'].get_value() == \
             "src2".encode('utf-16-le')
         assert src_files[1]['file_last_write'].get_value() == \
-            datetime.utcfromtimestamp(0)
+            datetime.utcfromtimestamp(0).replace(tzinfo=timezone.utc)
         assert src_files[1]['file_version_ls'].get_value() == 0
         assert src_files[1]['file_version_ms'].get_value() == 0
         assert not src_files[1]['copy_file'].get_value()
@@ -284,7 +285,7 @@ class TestPAExecSettingsMsg(object):
         assert dest_files[0]['filename'].get_value() == \
             "dest1".encode('utf-16-le')
         assert dest_files[0]['file_last_write'].get_value() == \
-            datetime.utcfromtimestamp(0)
+            datetime.utcfromtimestamp(0).replace(tzinfo=timezone.utc)
         assert dest_files[0]['file_version_ls'].get_value() == 0
         assert dest_files[0]['file_version_ms'].get_value() == 0
         assert not dest_files[0]['copy_file'].get_value()
@@ -292,7 +293,7 @@ class TestPAExecSettingsMsg(object):
         assert dest_files[1]['filename'].get_value() == \
             "dest2".encode('utf-16-le')
         assert dest_files[1]['file_last_write'].get_value() == \
-            datetime.utcfromtimestamp(0)
+            datetime.utcfromtimestamp(0).replace(tzinfo=timezone.utc)
         assert dest_files[1]['file_version_ls'].get_value() == 0
         assert dest_files[1]['file_version_ms'].get_value() == 0
         assert not dest_files[1]['copy_file'].get_value()
@@ -516,7 +517,7 @@ class TestPAExecSettingsBuffer(object):
         assert src_files[0]['filename'].get_value() == \
             "src1".encode('utf-16-le')
         assert src_files[0]['file_last_write'].get_value() == \
-            datetime.utcfromtimestamp(0)
+            datetime.utcfromtimestamp(0).replace(tzinfo=timezone.utc)
         assert src_files[0]['file_version_ls'].get_value() == 0
         assert src_files[0]['file_version_ms'].get_value() == 0
         assert not src_files[0]['copy_file'].get_value()
@@ -524,7 +525,7 @@ class TestPAExecSettingsBuffer(object):
         assert src_files[1]['filename'].get_value() == \
             "src2".encode('utf-16-le')
         assert src_files[1]['file_last_write'].get_value() == \
-            datetime.utcfromtimestamp(0)
+            datetime.utcfromtimestamp(0).replace(tzinfo=timezone.utc)
         assert src_files[1]['file_version_ls'].get_value() == 0
         assert src_files[1]['file_version_ms'].get_value() == 0
         assert not src_files[1]['copy_file'].get_value()
@@ -535,7 +536,7 @@ class TestPAExecSettingsBuffer(object):
         assert dest_files[0]['filename'].get_value() == \
             "dest1".encode('utf-16-le')
         assert dest_files[0]['file_last_write'].get_value() == \
-            datetime.utcfromtimestamp(0)
+            datetime.utcfromtimestamp(0).replace(tzinfo=timezone.utc)
         assert dest_files[0]['file_version_ls'].get_value() == 0
         assert dest_files[0]['file_version_ms'].get_value() == 0
         assert not dest_files[0]['copy_file'].get_value()
@@ -543,7 +544,7 @@ class TestPAExecSettingsBuffer(object):
         assert dest_files[1]['filename'].get_value() == \
             "dest2".encode('utf-16-le')
         assert dest_files[1]['file_last_write'].get_value() == \
-            datetime.utcfromtimestamp(0)
+            datetime.utcfromtimestamp(0).replace(tzinfo=timezone.utc)
         assert dest_files[1]['file_version_ls'].get_value() == 0
         assert dest_files[1]['file_version_ms'].get_value() == 0
         assert not dest_files[1]['copy_file'].get_value()
@@ -583,7 +584,7 @@ class TestPAExecFileInfo(object):
         assert actual['filename_len'].get_value() == 4
         assert actual['filename'].get_value() == "file".encode('utf-16-le-')
         assert actual['file_last_write'].get_value() == \
-            datetime.utcfromtimestamp(0)
+            datetime.utcfromtimestamp(0).replace(tzinfo=timezone.utc)
         assert actual['file_version_ls'].get_value() == 10
         assert actual['file_version_ms'].get_value() == 10
         assert actual['copy_file'].get_value()


### PR DESCRIPTION
Python 3.12 now strongly preffers timezone-aware datetime objects and some libraries have already been adapted to that. I didn't investigate which libraries, maybe the change is only a PR and we patched it in our distribution. However, the produced datetimes are now timezone-aware (or will be in near future) and this adapts pypsexec tests to this change.